### PR TITLE
Added README.md to MANIFEST.in to make source distribution tarball installable

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md


### PR DESCRIPTION
setup.py references README.md to get the package long description, but README.md is not copied into the source distribution tarball (on `setup.py sdist`) so installation of the tarball fails.

This adds a MANIFEST.in, which makes sure the README.md is copied into the source distribution tarball.
