### PR TITLE
Fixed MultiValueDictKeyError in django-1.6 following receipt by Gwildor

### DIFF
--- a/nested_inlines/templates/admin/edit_inline/stacked.html
+++ b/nested_inlines/templates/admin/edit_inline/stacked.html
@@ -14,7 +14,7 @@
   {% for fieldset in inline_admin_form %}
     {% include "admin/includes/fieldset.html" %}
   {% endfor %}
-  {% if inline_admin_form.has_auto_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
+  {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
   {{ inline_admin_form.fk_field.field }}
   {% if inline_admin_form.form.nested_formsets %}
     {% for inline_admin_formset in inline_admin_form.form.nested_formsets %}

--- a/nested_inlines/templates/admin/edit_inline/tabular.html
+++ b/nested_inlines/templates/admin/edit_inline/tabular.html
@@ -30,7 +30,7 @@
           {% if inline_admin_form.original %} {{ inline_admin_form.original }}{% endif %}
           {% if inline_admin_form.show_url %}<a href="../../../r/{{ inline_admin_form.original_content_type_id }}/{{ inline_admin_form.original.id }}/">{% trans "View on site" %}</a>{% endif %}
             </p>{% endif %}
-          {% if inline_admin_form.has_auto_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
+          {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
           {{ inline_admin_form.fk_field.field }}
           {% spaceless %}
           {% for fieldset in inline_admin_form %}


### PR DESCRIPTION
This patch makes django-nested-inline work with django-1.6, as described by [Gwildor](https://github.com/Gwildor) in the corresponding [issue](https://github.com/Soaa-/django-nested-inlines/issues/17).
