### PR TITLE
adjust github repo url in pip install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ it!
 
 ## Installation
 
-`pip install -e git+git://github.com/Soaa-/django-nested-inlines.git#egg=django-nested-inlines`
+`pip install -e git+git://github.com/silverfix/django-nested-inlines.git#egg=django-nested-inlines`
 
 ## Usage
 


### PR DESCRIPTION
Was the repo this code has been forked from, which is a bit outdated, I want to install the new stuff.
