### PR TITLE
Add back-compatibility on has_auto_field -> needs_explicit_pk_field fix

### DIFF
--- a/nested_inlines/admin.py
+++ b/nested_inlines/admin.py
@@ -1,3 +1,4 @@
+from django import VERSION as DJANGO_VERSION
 from django.contrib.admin.options import (ModelAdmin, InlineModelAdmin,
     csrf_protect_m, models, transaction, all_valid,
     PermissionDenied, unquote, escape, Http404, reverse)
@@ -217,6 +218,7 @@ class NestedModelAdmin(ModelAdmin):
             'inline_admin_formsets': inline_admin_formsets,
             'errors': AdminErrorList(form, formsets),
             'app_label': opts.app_label,
+            'django_version_lt_1_6': DJANGO_VERSION < (1, 6)
         }
         context.update(extra_context or {})
         return self.render_change_form(request, context, form_url=form_url, add=True)
@@ -314,6 +316,7 @@ class NestedModelAdmin(ModelAdmin):
             'inline_admin_formsets': inline_admin_formsets,
             'errors': AdminErrorList(form, formsets),
             'app_label': opts.app_label,
+            'django_version_lt_1_6': DJANGO_VERSION < (1, 6)
         }
         context.update(extra_context or {})
         return self.render_change_form(request, context, change=True, obj=obj, form_url=form_url)

--- a/nested_inlines/templates/admin/edit_inline/stacked.html
+++ b/nested_inlines/templates/admin/edit_inline/stacked.html
@@ -4,7 +4,6 @@
   <h2>{{ recursive_formset.opts.verbose_name_plural|title }}</h2>
 {{ recursive_formset.formset.management_form }}
 {{ recursive_formset.formset.non_form_errors }}
-
 {% for inline_admin_form in recursive_formset %}<div class="inline-related{% if forloop.last %} empty-form last-related{% endif %}" id="{{ recursive_formset.formset.prefix }}-{% if not forloop.last %}{{ forloop.counter0 }}{% else %}empty{% endif %}">
   <h3><b>{{ recursive_formset.opts.verbose_name|title }}:</b>&nbsp;<span class="inline_label">{% if inline_admin_form.original %}{{ inline_admin_form.original }}{% else %}#{{ forloop.counter }}{% endif %}</span>
     {% if inline_admin_form.show_url %}<a href="../../../r/{{ inline_admin_form.original_content_type_id }}/{{ inline_admin_form.original.id }}/">{% trans "View on site" %}</a>{% endif %}
@@ -14,7 +13,11 @@
   {% for fieldset in inline_admin_form %}
     {% include "admin/includes/fieldset.html" %}
   {% endfor %}
-  {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
+  {% if django_version_lt_1_6 %}
+    {% if inline_admin_form.has_auto_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
+  {% else %}
+    {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
+  {% endif %}
   {{ inline_admin_form.fk_field.field }}
   {% if inline_admin_form.form.nested_formsets %}
     {% for inline_admin_formset in inline_admin_form.form.nested_formsets %}

--- a/nested_inlines/templates/admin/edit_inline/tabular.html
+++ b/nested_inlines/templates/admin/edit_inline/tabular.html
@@ -30,7 +30,11 @@
           {% if inline_admin_form.original %} {{ inline_admin_form.original }}{% endif %}
           {% if inline_admin_form.show_url %}<a href="../../../r/{{ inline_admin_form.original_content_type_id }}/{{ inline_admin_form.original.id }}/">{% trans "View on site" %}</a>{% endif %}
             </p>{% endif %}
-          {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
+          {% if django_version_lt_1_6 %}
+            {% if inline_admin_form.has_auto_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
+          {% else %}
+            {% if inline_admin_form.needs_explicit_pk_field %}{{ inline_admin_form.pk_field.field }}{% endif %}
+          {% endif %}
           {{ inline_admin_form.fk_field.field }}
           {% spaceless %}
           {% for fieldset in inline_admin_form %}


### PR DESCRIPTION
With 457c474 commit, the compatibility with Django 1.5 was lost. We must use Django 1.5, so we add this fix to maintain back-compatibility.
