### PR TITLE
add package_data to be able to use 'python ./setup.py install' from local git source directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,8 @@ setup(
         'Programming Language :: Python',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
+    package_data={'nested_inlines' : ['templates/admin/edit_inline/*.html',
+                                      'static/admin/css/*.css',
+                                      'static/admin/js/*.js']},
 )
 


### PR DESCRIPTION
 instead use the git target
Note: add a "develop" target could be useful too.
